### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "type": "project",
     "require": {
         "php": ">=7.0.0",
-        "laravel/framework": "^5.6 | 5.5.*"
+        "laravel/framework": "^5.6 || 5.5.*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "type": "project",
     "require": {
         "php": ">=7.0.0",
-        "laravel/framework": "5.5.*"
+        "laravel/framework": ">=5.5.*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "type": "project",
     "require": {
         "php": ">=7.0.0",
-        "laravel/framework": ">=5.5.*"
+        "laravel/framework": ">=5.5.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "type": "project",
     "require": {
         "php": ">=7.0.0",
-        "laravel/framework": ">=5.5.0"
+        "laravel/framework": "^5.6 | 5.5.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This allows laravel-tabler to be installed on Laravel 5.6.x again. Currently it errors out requiring Laravel 5.5 when trying to install v1.1 on Laravel 5.6:

`- guszandy/laravel-tabler v1.1 requires laravel/framework 5.5.* -> satisfiable by laravel/framework[5.5.x-dev].`

This is because the composer file has been set to explicitly require Laravel 5.5.x.